### PR TITLE
Add November Glasgow meeting

### DIFF
--- a/_layouts/master.html
+++ b/_layouts/master.html
@@ -13,11 +13,11 @@
 
 
     <div id="header">
-		<div id="twitter"><a href="http://twitter.com/scotrug">follow us on twitter</a></div>
+                <div id="twitter"><a href="http://twitter.com/scotrug">follow us on twitter</a></div>
       <h1><a href="/">Scottish Ruby User Group</a></h1>
     </div>
 
-	<div id="content">
+        <div id="content">
 
     <div id="left">
       <div class="section">
@@ -43,7 +43,7 @@
         <h2>Meetings</h2>
         <h3 class='meeting-heading'>Glasgow</h3>
         <p>
-        There isn't currently a Glasgow meeting. Anyone want to start one up again?
+          We meet on the first Thursday of the month at 19:00.  November’s meeting will be at the <a href="http://www.cca-glasgow.com/saramago-caf/saramago-caf-bar">Saramango Café Bar</a>, watch out for future venues!
         </p>
         <h3 class='meeting-heading'>Edinburgh</h3>
         <p>We meet on the
@@ -83,9 +83,9 @@
       {{content}}
     </div>
 
-	<div class="reset_float"></div>
+        <div class="reset_float"></div>
 
-	</div>
+        </div>
 
     <div id="footer">
       <p>

--- a/_posts/2015-10-23-november-glasgow-meeting.md
+++ b/_posts/2015-10-23-november-glasgow-meeting.md
@@ -1,0 +1,15 @@
+---
+layout: post
+---
+
+Thursday 5 November 2015 marks the return of regular Ruby meetings to
+Glasgow!
+
+This month we will be at the
+[CCA Saramango Café Bar](http://www.cca-glasgow.com/saramago-caf/saramago-caf-bar)
+on Sauchiehall Street from 19:00.
+
+As this is the first Glasgow meetup for a while, this will be a chance
+to talk Ruby with new and seasoned developers, get to know the local
+Ruby community, and decide on what we want to get from future
+meetings.

--- a/code_of_conduct.html
+++ b/code_of_conduct.html
@@ -30,6 +30,7 @@ title: Code of Conduct
     <li>Alan Gardner <a href="mailto:urfolomeus@gmail.com">urfolomeus@gmail.com</a></li>
     <li>Paul Wilson <a href="mailto:paul.wilson@merecomplexities.com">paul.wilson@merecomplexities.com</a></li>
     <li>T.J. Sheehy <a href="mailto:timsheehy@gmail.com">timsheehy@gmail.com</a></li>
+    <li>David Jones <a href="mailto:david@djones.eu">david@djones.eu</a></li>
   </ul>
 
   <h2>License</h2>


### PR DESCRIPTION
I'm [starting the Glasgow Ruby meetings back up][1] :tada: so I've added details here (I've also added an [Open Tech Calendar event][2].)

I've added a post for the meeting, updated the Glasgow meeting blurb in the side bar, and added myself to the organisers section of the code of conduct.  Please check that this looks okay!

[1]: https://groups.google.com/forum/#!msg/scotrug/X0Z22Yut-B8/6QJqDRauBgAJ
[2]: https://opentechcalendar.co.uk/event/3343-glasgow-ruby-group-meetup