### PR TITLE
Rename CodeCraft to ScotRUG in the Code of Conduct

### DIFF
--- a/_layouts/master.html
+++ b/_layouts/master.html
@@ -32,7 +32,7 @@
       <div class="section">
         <h2>Code of Conduct</h2>
         <p>
-        To ensure we provide a welcoming and friendly environment for all, attendees, speakers, organisers, and volunteers at any CodeCraft meetup are required to conform to our <a href="/code_of_conduct.html" title="Code of Conduct">Code of Conduct</a>.
+        To ensure we provide a welcoming and friendly environment for all, attendees, speakers, organisers, and volunteers at any ScotRUG meetup are required to conform to our <a href="/code_of_conduct.html" title="Code of Conduct">Code of Conduct</a>.
         </p>
         <p>
         Organizers will enforce this code throughout the meetup and meetup-related social events.

--- a/code_of_conduct.html
+++ b/code_of_conduct.html
@@ -6,20 +6,20 @@ title: Code of Conduct
 <div class='post'>
   <h2>Code of Conduct</h2>
   <p>
-  The Scottish Ruby User Group (ScotRug) is an event intended for education, networking, and community. To ensure it is a welcoming and friendly environment for all, attendees, speakers, organisers, and volunteers at any CodeCraft meetup are required to conform to the following Code of Conduct. Organizers will enforce this code throughout the meetup and meetup-related social events.
+  The Scottish Ruby User Group (ScotRUG) is an event intended for education, networking, and community. To ensure it is a welcoming and friendly environment for all, attendees, speakers, organisers, and volunteers at any ScotRUG meetup are required to conform to the following Code of Conduct. Organizers will enforce this code throughout the meetup and meetup-related social events.
   </p>
 
   <h2>Welcoming Environment</h2>
   <p>
-  ScotRug is dedicated to providing a harassment-free community for everyone, regardless of sex, gender identity or expression, sexual orientation, disability, physical appearance, age, body size, race, nationality, or religious beliefs. We do not tolerate harassment of community members in any form. Participants violating these rules may be sanctioned or expelled from the community at the discretion of the ScotRug organisers.
+  ScotRUG is dedicated to providing a harassment-free community for everyone, regardless of sex, gender identity or expression, sexual orientation, disability, physical appearance, age, body size, race, nationality, or religious beliefs. We do not tolerate harassment of community members in any form. Participants violating these rules may be sanctioned or expelled from the community at the discretion of the ScotRUG organisers.
   </p>
 
   <p>
-  Harassment includes offensive verbal or written comments related to sex, gender identity or expression, sexual orientation, disability, physical appearance, age, body size, race, nationality, or religious beliefs, deliberate intimidation, threats, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention. Sexual language and imagery is not appropriate for any ScotRug event or communication channel. Community members asked to stop any harassing behaviour are expected to comply immediately. Sponsors and presenters are also subject to the anti-harassment policy.
+  Harassment includes offensive verbal or written comments related to sex, gender identity or expression, sexual orientation, disability, physical appearance, age, body size, race, nationality, or religious beliefs, deliberate intimidation, threats, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention. Sexual language and imagery is not appropriate for any ScotRUG event or communication channel. Community members asked to stop any harassing behaviour are expected to comply immediately. Sponsors and presenters are also subject to the anti-harassment policy.
   </p>
 
   <p>
-  If a community member engages in harassing behaviour, the ScotRug organisers may take any action they deem appropriate, including warning the offender or expulsion from the ScotRug community. If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a ScotRug organiser immediately.
+  If a community member engages in harassing behaviour, the ScotRUG organisers may take any action they deem appropriate, including warning the offender or expulsion from the ScotRUG community. If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a ScotRUG organiser immediately.
   </p>
 
   <h2>Contact information</h2>


### PR DESCRIPTION
The reference to “CodeCraft” was added along with the Code of Conduct when it was copied from [their website][1] in 48c885aa7.  I’ve changed it to “ScotRUG”, assuming it was an oversight.

I’ve also changed the capitalization of “ScotRug” to “ScotRUG” across the Code of Conduct for consistency with the rest of the site.

[1]: http://www.codecraftuk.org/code-of-conduct.html