### PR TITLE
Update "About" sidebar

### DIFF
--- a/_includes/about.md
+++ b/_includes/about.md
@@ -1,0 +1,84 @@
+## About
+
+The Scottish Ruby User Group is a collection of people who are linked
+with Scotland and have an interest in [Ruby][] and [Ruby on Rails][].
+We meet every month in [Glasgow](#glasgow) and [Edinburgh](#edinburgh)
+for presentations from members and guests, and a chat about Ruby and
+related subjects.  All are welcome, and there are no subscriptions or
+costs involved.
+
+Meetings are announced in advance on the [mailing list][] and
+[Open Tech Calendar][], and follow our [code of conduct].
+
+[Ruby]: https://www.ruby-lang.org/en/
+[Ruby on Rails]: http://rubyonrails.org/
+
+
+## Glasgow
+
+We meet in Glasgow at 18:30 on the first Thursday of the month.  The
+next Glasgow meeting will be in [tictoc][]’s office on
+[Newton Terrace][], off Sauchiehall Street.
+
+[tictoc]: http://www.tictocfamily.com/
+[Newton Terrace]: https://www.openstreetmap.org/way/4642296#map=17/55.86572/-4.27479 "Map"
+
+
+## Edinburgh
+
+We meet in Edinburgh on the third Thursday of the month at 19:30
+onwards.  While [FreeAgent][] are busy moving offices, meetings are
+currently at [CodeBase][], in Argyle House on the corner of
+[West Port and Lady Lawson Street][].  Head to floor M (top floor) and
+you will be directed to the meeting.
+
+[Open Tech Calendar]: https://opentechcalendar.co.uk/group/27-scotrug
+[CodeBase]: http://www.thisiscodebase.com/
+[West Port and Lady Lawson Street]: https://goo.gl/maps/ZuPgH "Map"
+
+
+## [Mailing List][]
+
+You can browse and subscribe to the list using the
+[ScotRUG Google Group information page][mailing list].  The list is
+for announcements of activities and general Ruby support and
+discussion; feel free to post any questions you may have.
+
+[mailing list]: https://groups.google.com/forum/#!forum/scotrug
+
+
+## [IRC][]
+
+We use the [freenode][] channel [`#scotrug`][IRC].
+
+[freenode]: https://www.freenode.net/
+[IRC]: https://kiwiirc.com/client/irc.freenode.net/scotrug
+
+
+## [Code of Conduct][]
+
+To ensure we provide a welcoming and friendly environment for all,
+attendees, speakers, organisers, and volunteers at any ScotRUG meetup
+are required to conform to our [code of conduct][].
+
+Organizers will enforce this code throughout the meetup and
+meetup-related social events.
+
+[code of conduct]: /code_of_conduct.html
+
+
+## [Videos][]
+
+[Videos of previous presentations][videos] have been provided courtesy
+of [Cultivate][].
+
+[videos]: http://vimeo.com/edgecaseuk/videos
+
+
+## Supported by
+
+[![FreeAgent](/images/freeagent-logo.png)][FreeAgent]
+[![Cultivate](/images/cultivate.png)][Cultivate]
+
+[FreeAgent]: http://www.freeagent.com/
+[Cultivate]: http://www.cultivatehq.com/

--- a/_layouts/master.html
+++ b/_layouts/master.html
@@ -1,94 +1,27 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-  <title>Scottish Ruby User Group  </title>
-  <link rel="stylesheet" href="/stylesheets/reset.css" type="text/css" media="screen">
-  <link rel="stylesheet" href="/stylesheets/scotrug.css" type="text/css" media="screen">
-<link rel="index" title="Scottish Ruby User Group" href="http://scotrug.org/">
-<link rel="canonical" href="http://scotrug.org/">
-</head>
-<body>
-  <div id="page">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <title>Scottish Ruby User Group  </title>
+    <link rel="stylesheet" href="/stylesheets/reset.css" type="text/css" media="screen">
+    <link rel="stylesheet" href="/stylesheets/scotrug.css" type="text/css" media="screen">
+    <link rel="index" title="Scottish Ruby User Group" href="http://scotrug.org/">
+    <link rel="canonical" href="http://scotrug.org/">
+  </head>
+  <body>
     <div class="header">
       <a class="twitter-link" href="http://twitter.com/scotrug">Follow us on Twitter</a>
       <h1><a href="/">Scottish Ruby User Group</a></h1>
     </div>
-
-        <div id="content">
-
-    <div id="left">
-      <div class="section">
-        <h2 >About</h2>
-        <p>The
-          Scottish Ruby User Group is a collection of people who are linked with
-          Scotland and have an interest in Ruby and, invariably, Ruby on Rails.
-          We meet every month for presentations from members and guests and a chat about Ruby and Ruby Related events. Everybody is
-          welcome and there are no subscriptions/costs involved.</p>
-
+    <div id="content">
+      <div id="left">
+        {% capture about %}{% include about.md %}{% endcapture %}
+        {{ about | markdownify }}
       </div>
-      <div class="section">
-        <h2>Code of Conduct</h2>
-        <p>
-        To ensure we provide a welcoming and friendly environment for all, attendees, speakers, organisers, and volunteers at any ScotRUG meetup are required to conform to our <a href="/code_of_conduct.html" title="Code of Conduct">Code of Conduct</a>.
-        </p>
-        <p>
-        Organizers will enforce this code throughout the meetup and meetup-related social events.
-        </p>
-        <p>The Code of Conduct is <a href="/code_of_conduct.html" title="Code of Conduct">here</a></p>
+      <div id="posts">
+        {{ content }}
       </div>
-      <div class="section">
-        <h2>Meetings</h2>
-        <h3 class='meeting-heading'>Glasgow</h3>
-        <p>The Glasgow meeting happens on the first Thursday of the month from 18:30.  Next month’s venue will be announced on the <a href="https://groups.google.com/forum/#!forum/scotrug">mailing list</a> and <a href="https://opentechcalendar.co.uk/group/27-scotrug">Open Tech Calendar</a>.</p>
-        <h3 class='meeting-heading'>Edinburgh</h3>
-        <p>We meet on the
-        third Thursday of the month at 19:30 onwards.
-        </p>
-        <p>
-        While <a href="http://www.freeagent.com">FreeAgent</a> are busy moving offices, meetings are currently at <a href="http://www.thisiscodebase.com">CodeBase</a>, in Argyle House on the corner of <a href="https://goo.gl/maps/ZuPgH">West Port and Lady Lawson Street]</a>. Head to floor M (top floor) and you will be directed to the meeting.
-          </p>
-      </div>
-      <div class="section">
-        <h2>Mailing List / Google Group</h2>
-        <p>You can subscribe to the mailing list using the&nbsp;<a href="http://groups.google.com/group/scotrug">ScotRUG Google Group information page</a>. The list is for announcements of&nbsp;<strong>ScotRUG</strong>&nbsp;activities
-          and general support/discussion about Ruby (and Ruby on Rails!). Feel
-          free to post any questions you have; we’re an open and friendly
-          community. As of the last time I checked, the mailing list has around
-          75 members.</p>
-      </div>
-      <div class="section">
-        <h2>Video</h2>
-
-        <p>Videos of previous presentations, provided courtesy of <a href="http://cultivatehq.com">Cultivate</a>, are available <a href="http://vimeo.com/edgecaseuk">here</a>.</p>
-      </div>
-      <div class="section">
-        <h3>IRC group</h3>
-        <p>We now also have an IRC channel available. It’s pretty quiet at the
-          moment, but I’m sure we’ll pick up a number of idlers now that it’s
-          been announced. You can find us on <code>irc.freenode.net</code>&nbsp;in&nbsp;<code>#<strong>scotrug</strong></code>.</p>
-
-      </div>
-      <div class="section">
-        <h3>Supported by</h3>
-        <a href="http://www.freeagentcentral.com/"><img src="/images/freeagent-logo.png"/></a>
-        <a href="http://cultivatehq.com"><img src="/images/cultivate.png"></a>
-      </div>
+      <div class="reset_float"></div>
     </div>
-    <div id="posts">
-      {{content}}
-    </div>
-
-        <div class="reset_float"></div>
-
-        </div>
-
-    <div id="footer">
-      <p>
-      </p>
-    </div>
-  </div>
-
-
-</body>
+  </body>
 </html>

--- a/stylesheets/scotrug.css
+++ b/stylesheets/scotrug.css
@@ -1,67 +1,37 @@
-body{
-  margin: 0px;
-  padding: 0px;
+body {
+  margin: 20px auto;
+  padding: 0;
   background: #3877bc url(/images/bkg.jpg) repeat left top;
-  text-align: justify;
   font: 12px Arial, Helvetica, sans-serif;
   color: #666363;
-
+  width: 980px;
 }
 
 h1, h2, h3 {
-  font-size: 1.82em;
   font-weight: normal;
-  font-family: Arial, Helvetica, sans-serif;
-  color: #000000;
 }
 
-.post h1, .post h2, .post h3{
-  font-size: 1.1em;
-  padding: 20px 0 10px;
-}
-
-a{
+a {
   color: #333;
-  text-decoration: underline;
-}
-a:hover{
-  text-decoration: underline;
-}
-
-
-code{
-  background: #dfdfdf;
-  display: block;
-  padding-left: 40px;
-  margin: 20px 0;
-  color: black;
 }
 
 blockquote {
-    margin-left: 0.8em;
-    font-style: italic;
-}
-
-#page {
-  margin:20px auto;
-  padding:0;
-  text-align:left;
-  width:980px;
+  margin-left: 0.8em;
+  font-style: italic;
 }
 
 .header {
   background: url(/images/ruby.png) no-repeat left bottom;
-  padding: 70px 0 3px 0;
+  padding-top: 70px;
+  padding-bottom: 3px;
 }
 
 .header h1 {
-  margin-left:80px;
-  text-transform: lowercase;
+  margin-left: 80px;
   letter-spacing: -3px;
   font-size: 3.5em;
-  color: #FFFFFF;
-  text-shadow: 1px 1px 1px #000;
-  filter: dropshadow(color=#000, offx=1, offy=1);
+  color: white;
+  text-shadow: 1px 1px 1px black;
 }
 
 .header a {
@@ -84,11 +54,7 @@ blockquote {
 #content {
   background: url(/images/inner_bkg.jpg) repeat left top;
   padding: 20px;
-
   margin-top: 30px;
-
-  -webkit-border-radius: 20px;
-  -moz-border-radius: 20px;
   border-radius: 20px;
 }
 
@@ -97,85 +63,71 @@ blockquote {
   float: left;
   width: 280px;
   color: #b9d2f1;
+  margin-top: -20px;
 }
 
-#left .section{
-  padding: 0px 20px 20px 0px;
+#left p {
+  padding-right: 20px;
+  margin: 0.5em 0;
 }
 
-#left a{
+#left a {
   color: white;
 }
 
-#left .section h2, #left .section h3{
-  text-transform: lowercase;
+#left h2 {
+  padding-top: 20px;
   margin-bottom: 15px;
   letter-spacing: -1px;
   font-size: 1.5em;
-  font-weight: normal;
-  color: #FFFFFF;
-
-  text-shadow: 1px 1px 1px #000;
-  filter: dropshadow(color=#000, offx=1, offy=1);
+  color: white;
+  text-shadow: 1px 1px 1px black;
 }
 
-#posts{
-  /*margin-top: 50px;*/
+#left img {
+  padding: 15px 0 5px;
+}
+
+#posts {
   width: 600px;
-  /*position: absolute;
-  left: 420px;*/
   margin-left: 280px;
   font-size: 1.2em;
   padding: 40px 30px 10px 30px;
-
-  background-color: #fff;
-  -webkit-border-radius: 15px;
-  -moz-border-radius: 15px;
+  background-color: white;
   border-radius: 15px;
-
-  -webkit-box-shadow: 0px 0px 20px #212552;
-  -moz-box-shadow: 0px 0px 20px #212552;
   box-shadow: 0px 0px 20px #212552;
 }
 
 .post {
   padding-bottom: 50px;
 }
-.post h2{
+
+.post h1, .post h2, .post h3 {
+  padding-top: 20px;
+  padding-bottom: 10px;
+}
+
+.post h2 {
   font-size: 2em;
   color: #96233c;
 }
 
-.post h2 a{
+.post h2 a {
   color: #96233c;
   text-decoration: none;
 }
 
-.post p{
+.post p {
   padding: 5px 0;
 }
 
-
-#left p{
-  margin: 0.5em 0;
-}
-
-.post .date{
+.post .date {
   font-size:60%;
   padding-bottom:10px;
-
 }
 
-.post .body{
-}
-
-.section img{
-  padding: 15px 0 5px;
-}
-
-
-.post ul{
-  padding: 5px 0
+.post ul {
+  padding: 5px 0;
 }
 
 .post li {
@@ -189,11 +141,4 @@ blockquote {
 
 iframe {
   padding: 20px;
-}
-
-
-.section .meeting-heading {
-  font-size: 1.3em !important;
-  margin-bottom: 3px !important;
-  margin-top: 5px;
 }


### PR DESCRIPTION
I've updated the information about the Glasgow group, and taken the opportunity to update the sidebar a bit.  I've left some stuff that may be out of date: there have been no new videos added since the last Scottish Ruby Conference, and I'm not sure if anyone uses IRC.  Hopefully the changes below are uncontroversial.

- Sidebar is now an included Markdown file to ease editing
- `<code>` styling has been removed to prevent text intended to be mono-space displaying as a block
- Sections are arranged in a more logical order
- Links have been named more informatively
- The style sheet and page structure has been cleaned up a little, and obsolete vendor prefixes removed
- Headings are now displayed in Title Case

![old-vs-new-sidebar](https://cloud.githubusercontent.com/assets/6856120/11431706/84c5d02e-9495-11e5-8e73-23ea1b51ca44.png)

