### PR TITLE
January Glasgow Meeting

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,2 +1,5 @@
 permalink: date
 exclude: [config.ru, Gemfile, Gemfile.lock, Procfile, Rakefile, README.md, vendor, Dockerfile, docker-compose.yml, README.markdown, gen.rb, scotrug.rb]
+
+# Allow using the meeting date for posts.
+future: true

--- a/_includes/about.md
+++ b/_includes/about.md
@@ -16,12 +16,10 @@ Meetings are announced in advance on the [mailing list][] and
 
 ## Glasgow
 
-We meet in Glasgow at 18:30 on the first Thursday of the month.  The
-next Glasgow meeting will be in [tictoc][]’s office on
-[Newton Terrace][], off Sauchiehall Street.
-
-[tictoc]: http://www.tictocfamily.com/
-[Newton Terrace]: https://www.openstreetmap.org/way/4642296#map=17/55.86572/-4.27479 "Map"
+We meet in Glasgow at 18:30 on the first Thursday of the month.  This
+month we will be at the
+[CCA Saramango Café Bar](http://www.cca-glasgow.com/saramago-caf/saramago-caf-bar)
+on [Sauchiehall Street](https://opentechcalendar.co.uk/map?venue=12-cca-centre-for-contemporary-arts).
 
 
 ## Edinburgh

--- a/_posts/2016-01-07-january-glasgow-meeting.md
+++ b/_posts/2016-01-07-january-glasgow-meeting.md
@@ -1,0 +1,12 @@
+---
+layout: post
+---
+
+We are meeting up for the first time this year from **18:30** on
+**Thursday 7 January** at the CCA.  Details and a map to the venue are
+on the
+[Open Tech Calendar event page](https://opentechcalendar.co.uk/event/3545-glasgow-ruby-group).
+
+We’ll find a table in the courtyard café downstairs, on the right past
+the shop as you walk in from the Sauchiehall Street entrance.  See you
+there!


### PR DESCRIPTION
`future: true` publishes this post, even though it’s dated in the future.