### PR TITLE
Add Twitter cards

### DIFF
--- a/_layouts/master.html
+++ b/_layouts/master.html
@@ -2,7 +2,8 @@
 <html>
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-    <title>Scottish Ruby User Group</title>
+    {% capture title %}{% if page.title %}{{ page.title }} | {% endif %}Scottish Ruby User Group{% endcapture %}
+    <title>{{ title }}</title>
     <link rel="stylesheet" href="/style.css" media="screen">
     <link rel="index" title="Scottish Ruby User Group" href="http://scotrug.org/">
     <link rel="canonical" href="http://scotrug.org/">

--- a/_layouts/master.html
+++ b/_layouts/master.html
@@ -7,6 +7,12 @@
     <link rel="stylesheet" href="/style.css" media="screen">
     <link rel="index" title="Scottish Ruby User Group" href="http://scotrug.org/">
     <link rel="canonical" href="http://scotrug.org/">
+    {% if page.excerpt %}
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:site" content="@scotrug">
+    <meta name="og:title" content="{{ title }}">
+    <meta name="og:description" content="{{ page.excerpt | strip_html }}">
+    {% endif %}
   </head>
   <body>
     <div class="header">

--- a/index.html
+++ b/index.html
@@ -1,6 +1,5 @@
 ---
 layout: master
-title: Home
 ---
 {% for post in site.posts %}
 <div class='post'>


### PR DESCRIPTION
Twitter summary cards show a preview of the page below a tweet linking to it.  More information here: https://dev.twitter.com/cards/types/summary

I've added cards for all pages with excerpts, which is all posts currently.  The [Card Validator](https://cards-dev.twitter.com/validator) can only be used  on live sites; I've got a `gh-pages` branch on my fork, so try e.g. http://kotoshenya.github.io/scotrug.github.io/2016/01/07/january-glasgow-meeting.html.