### PR TITLE
Adds pagination to the site

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,9 +4,12 @@ exclude: [config.ru, Gemfile, Gemfile.lock, Procfile, Rakefile, README.md, vendo
 # Allow using the meeting date for posts.
 future: true
 
+paginate: 12
+
 markdown: kramdown
 kramdown:
   input: GFM
 
 plugins:
   - jekyll-feed
+  - jekyll-paginate

--- a/index.html
+++ b/index.html
@@ -1,10 +1,23 @@
 ---
 layout: master
 ---
-{% for post in site.posts %}
-<div class='post'>
-  <h2><a href='{{post.url}}'>{{post.title}}</a></h2>
-  <div class='date'>posted {{post.date | date_to_string}}</div>
-  <div class='body'>{{ post.content | replace:'<iframe','<!-- <iframe' | replace:'</iframe>','</iframe> -->' }}</div>
-</div>
+{% for post in paginator.posts %}
+  <div class='post'>
+    <h2><a href='{{post.url}}'>{{post.title}}</a></h2>
+    <div class='date'>posted {{post.date | date_to_string}}</div>
+    <div class='body'>{{ post.content | replace:'<iframe','<!-- <iframe' | replace:'</iframe>','</iframe> -->' }}</div>
+  </div>
 {% endfor %}
+<div class="pagination">
+  {% if paginator.previous_page %}
+    <a href="{{ paginator.previous_page_path }}" class="previous">
+      Previous
+    </a>
+  {% endif %}
+  <span class="page_number ">
+    Page: {{ paginator.page }} of {{ paginator.total_pages }}
+  </span>
+  {% if paginator.next_page %}
+    <a href="{{ paginator.next_page_path }}" class="next">Next</a>
+  {% endif %}
+</div>


### PR DESCRIPTION
The blog has been a one-page thing since it was built. Though it builds quickly, there's quite a lot of information to page through and makes the page feel odd. The upside to this is that the page will load slightly faster (though not much faster).

The downside is that it becomes harder to find historical posts, as you can't user your browser to find in page.

I think overall it works better. We've chosen 12 posts per page, to reflect a calendar year, though note that we rarely run 12 meetups a year.